### PR TITLE
404 not foundなのに200のステータスコードが返る

### DIFF
--- a/Gateway.class.php
+++ b/Gateway.class.php
@@ -17,6 +17,7 @@ namespace Citrus;
 
 use Citrus\Autoloader\CitrusAutoloaderException;
 use Citrus\Document\CitrusDocumentRouter;
+use Citrus\Http\CitrusHttpHeader;
 use Citrus\Sqlmap\CitrusSqlmapException;
 use Exception;
 
@@ -146,8 +147,8 @@ class CitrusGateway
         }
         catch (CitrusAutoloaderException $e)
         {
-            header("HTTP/1.0 404 Not Found");
             // 404でリダイレクトの様に振る舞う
+            CitrusHttpHeader::status404();
             CitrusSession::$router = CitrusDocumentRouter::parseURL(
                 CitrusConfigure::$CONFIGURE_ITEM->routing->error404
             );

--- a/Gateway.class.php
+++ b/Gateway.class.php
@@ -146,6 +146,7 @@ class CitrusGateway
         }
         catch (CitrusAutoloaderException $e)
         {
+            header("HTTP/1.0 404 Not Found");
             // 404でリダイレクトの様に振る舞う
             CitrusSession::$router = CitrusDocumentRouter::parseURL(
                 CitrusConfigure::$CONFIGURE_ITEM->routing->error404

--- a/controller/Page.class.php
+++ b/controller/Page.class.php
@@ -22,6 +22,7 @@ use Citrus\CitrusMessage;
 use Citrus\CitrusSession;
 use Citrus\Document\CitrusDocumentPagecode;
 use Citrus\Document\CitrusDocumentRouter;
+use Citrus\Http\CitrusHttpHeader;
 use Citrus\Library\CitrusLibrarySmarty3;
 use Exception;
 use Smarty_Internal_Template;
@@ -91,12 +92,12 @@ class CitrusControllerPage
         }
         catch (CitrusException $e)
         {
-            header("HTTP/1.0 404 Not Found");
+            CitrusHttpHeader::status404();
             throw $e;
         }
         catch (Exception $e)
         {
-            header("HTTP/1.0 404 Not Found");
+            CitrusHttpHeader::status404();
             throw CitrusException::convert($e);
         }
     }

--- a/http/Header.class.php
+++ b/http/Header.class.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * @copyright   Copyright 2017, Citrus/besidesplus All Rights Reserved.
+ * @author      take64 <take64@citrus.tk>
+ * @license     http://www.citrus.tk/
+ */
+
+namespace Citrus\Http;
+
+
+class CitrusHttpHeader
+{
+    /**
+     * status code 404
+     * 404 Not Found を返す
+     */
+    public static function status404()
+    {
+        header("HTTP/1.0 404 Not Found");
+    }
+}


### PR DESCRIPTION
404エラーの時に、404ページを返していたがステータスコードは200を返していた。

ついでにheader返却用クラスも作成