### PR TITLE
CitronIssue作成時の変更点

### DIFF
--- a/Autoloader.class.php
+++ b/Autoloader.class.php
@@ -25,8 +25,6 @@ class CitrusAutoloader
 
     /**
      * autoload framework
-     *
-     * @throws CitrusAutoloaderException
      */
     public static function autoloadFramework()
     {
@@ -82,8 +80,6 @@ class CitrusAutoloader
 
     /**
      * autoload application
-     *
-     * @throws CitrusAutoloaderException
      */
     public static function autoloadApplication()
     {

--- a/Configure.class.php
+++ b/Configure.class.php
@@ -40,6 +40,9 @@ class CitrusConfigure
     public static $DIR_BUSINESS;
 
     /** @var string dir */
+    public static $DIR_BUSINESS_CAPSULE;
+
+    /** @var string dir */
     public static $DIR_BUSINESS_ENTITY;
 
     /** @var string dir */
@@ -139,6 +142,7 @@ class CitrusConfigure
         self::$DIR_APP                  = $path_application_dir;
         // dir business
         self::$DIR_BUSINESS             = self::$DIR_APP . '/Business';
+        self::$DIR_BUSINESS_CAPSULE     = self::$DIR_BUSINESS . '/Capsule';
         self::$DIR_BUSINESS_ENTITY      = self::$DIR_BUSINESS . '/Entity';
         self::$DIR_BUSINESS_FORMMAP     = self::$DIR_BUSINESS . '/Formmap';
         self::$DIR_BUSINESS_SERVICE     = self::$DIR_BUSINESS . '/Service';

--- a/Configure.class.php
+++ b/Configure.class.php
@@ -78,7 +78,6 @@ class CitrusConfigure
      * configure initilize
      *
      * @param string $path_configure
-     * @throws Autoloader\CitrusAutoloaderException
      */
     public static function initialize($path_configure)
     {

--- a/Formmap.class.php
+++ b/Formmap.class.php
@@ -16,6 +16,7 @@ use Citrus\Formmap\CitrusFormmapSearch;
 use Citrus\Formmap\CitrusFormmapSelect;
 use Citrus\Formmap\CitrusFormmapSubmit;
 use Citrus\Formmap\CitrusFormmapText;
+use Citrus\Formmap\CitrusFormmapTextarea;
 use Exception;
 
 class CitrusFormmap
@@ -122,15 +123,16 @@ class CitrusFormmap
                 {
                     $form = null;
                     switch ($element['form_type']) {
-                        case CitrusFormmapElement::FORM_TYPE_ELEMENT: $form = new CitrusFormmapElement($element);   break;
-                        case CitrusFormmapElement::FORM_TYPE_HIDDEN : $form = new CitrusFormmapHidden($element);    break;
-                        case CitrusFormmapElement::FORM_TYPE_PASSWD : $form = new CitrusFormmapPassword($element);  break;
-                        case CitrusFormmapElement::FORM_TYPE_SELECT : $form = new CitrusFormmapSelect($element);    break;
-                        case CitrusFormmapElement::FORM_TYPE_SUBMIT : $form = new CitrusFormmapSubmit($element);    break;
-                        case CitrusFormmapElement::FORM_TYPE_BUTTON : $form = new CitrusFormmapButton($element);    break;
-                        case CitrusFormmapElement::FORM_TYPE_TEXT   : $form = new CitrusFormmapText($element);      break;
-                        case CitrusFormmapElement::FORM_TYPE_SEARCH : $form = new CitrusFormmapSearch($element);    break;
-                        default                                     :                                               break;
+                        case CitrusFormmapElement::FORM_TYPE_ELEMENT    : $form = new CitrusFormmapElement($element);   break;
+                        case CitrusFormmapElement::FORM_TYPE_HIDDEN     : $form = new CitrusFormmapHidden($element);    break;
+                        case CitrusFormmapElement::FORM_TYPE_PASSWD     : $form = new CitrusFormmapPassword($element);  break;
+                        case CitrusFormmapElement::FORM_TYPE_SELECT     : $form = new CitrusFormmapSelect($element);    break;
+                        case CitrusFormmapElement::FORM_TYPE_SUBMIT     : $form = new CitrusFormmapSubmit($element);    break;
+                        case CitrusFormmapElement::FORM_TYPE_BUTTON     : $form = new CitrusFormmapButton($element);    break;
+                        case CitrusFormmapElement::FORM_TYPE_TEXT       : $form = new CitrusFormmapText($element);      break;
+                        case CitrusFormmapElement::FORM_TYPE_TEXTAREA   : $form = new CitrusFormmapTextarea($element);  break;
+                        case CitrusFormmapElement::FORM_TYPE_SEARCH     : $form = new CitrusFormmapSearch($element);    break;
+                        default                                         :                                               break;
                     }
                     // 外部情報の設定
                     $form->id = $element_id;

--- a/Formmap.class.php
+++ b/Formmap.class.php
@@ -332,6 +332,7 @@ class CitrusFormmap
             {
                 continue;
             }
+            $one->convertType();
             $value = $one->filter();
             $object->setFromContext($one->property, $value);
         }

--- a/Service.class.php
+++ b/Service.class.php
@@ -229,9 +229,9 @@ class CitrusService
      * @return CitrusDatabaseColumn[]
      * @throws CitrusSqlmapException
      */
-    public function selections(CitrusDatabaseColumn $condition)
+    public function facesSelections(CitrusDatabaseColumn $condition)
     {
-        return $this->callDao()->selections($condition);
+        return $this->callDao()->facesSelections($condition);
     }
 
 

--- a/Service.class.php
+++ b/Service.class.php
@@ -12,6 +12,7 @@ use Citrus\Database\CitrusDatabaseColumn;
 use Citrus\Database\CitrusDatabaseResult;
 use Citrus\Sqlmap\CitrusSqlmapClient;
 use Citrus\Sqlmap\CitrusSqlmapCrud;
+use Citrus\Sqlmap\CitrusSqlmapException;
 
 class CitrusService
 {
@@ -30,6 +31,7 @@ class CitrusService
      *
      * @param CitrusDatabaseColumn $condition
      * @return CitrusDatabaseColumn[]
+     * @throws CitrusSqlmapException
      */
     public function summaries(CitrusDatabaseColumn $condition)
     {
@@ -43,6 +45,7 @@ class CitrusService
      *
      * @param CitrusDatabaseColumn $condition
      * @return CitrusDatabaseColumn
+     * @throws CitrusSqlmapException
      */
     public function summary(CitrusDatabaseColumn $condition)
     {
@@ -56,6 +59,7 @@ class CitrusService
      *
      * @param CitrusDatabaseColumn $condition
      * @return int
+     * @throws CitrusSqlmapException
      */
     public function count(CitrusDatabaseColumn $condition)
     {
@@ -69,6 +73,7 @@ class CitrusService
      *
      * @param CitrusDatabaseColumn $condition
      * @return CitrusDatabaseColumn
+     * @throws CitrusSqlmapException
      */
     public function last(CitrusDatabaseColumn $condition)
     {
@@ -82,6 +87,7 @@ class CitrusService
      *
      * @param CitrusDatabaseColumn $condition
      * @return bool
+     * @throws CitrusSqlmapException
      */
     public function exist(CitrusDatabaseColumn $condition)
     {
@@ -95,6 +101,7 @@ class CitrusService
      *
      * @param CitrusDatabaseColumn $condition
      * @return CitrusDatabaseResult[]
+     * @throws CitrusSqlmapException
      */
     public function names(CitrusDatabaseColumn $condition)
     {
@@ -108,6 +115,7 @@ class CitrusService
      *
      * @param CitrusDatabaseColumn $condition
      * @return array
+     * @throws CitrusSqlmapException
      */
     public function nameForList(CitrusDatabaseColumn $condition)
     {
@@ -129,6 +137,7 @@ class CitrusService
      *
      * @param CitrusDatabaseColumn $condition
      * @return CitrusDatabaseColumn
+     * @throws CitrusSqlmapException
      */
     public function name(CitrusDatabaseColumn $condition)
     {
@@ -142,6 +151,7 @@ class CitrusService
      *
      * @param CitrusDatabaseColumn $condition
      * @return CitrusDatabaseColumn[]
+     * @throws CitrusSqlmapException
      */
     public function details(CitrusDatabaseColumn $condition)
     {
@@ -153,9 +163,9 @@ class CitrusService
     /**
      * call detail record
      *
-     * @access  public
-     * @param   CitrusDatabaseColumn $condition
-     * @return  CitrusDatabaseColumn
+     * @param CitrusDatabaseColumn $condition
+     * @return CitrusDatabaseColumn
+     * @throws CitrusSqlmapException
      */
     public function detail(CitrusDatabaseColumn $condition)
     {
@@ -169,6 +179,7 @@ class CitrusService
      *
      * @param CitrusDatabaseColumn $entity
      * @return bool
+     * @throws CitrusSqlmapException
      */
     public function regist(CitrusDatabaseColumn $entity)
     {
@@ -185,6 +196,7 @@ class CitrusService
      *
      * @param CitrusDatabaseColumn $entity
      * @return bool
+     * @throws CitrusSqlmapException
      */
     public function modify(CitrusDatabaseColumn $entity)
     {
@@ -201,6 +213,7 @@ class CitrusService
      *
      * @param CitrusDatabaseColumn $condition
      * @return bool
+     * @throws CitrusSqlmapException
      */
     public function remove(CitrusDatabaseColumn $condition)
     {
@@ -214,6 +227,7 @@ class CitrusService
      *
      * @param CitrusDatabaseColumn $condition
      * @return CitrusDatabaseColumn[]
+     * @throws CitrusSqlmapException
      */
     public function selections(CitrusDatabaseColumn $condition)
     {
@@ -227,6 +241,7 @@ class CitrusService
      *
      * @param CitrusDatabaseColumn $condition
      * @return CitrusDatabaseColumn[]
+     * @throws CitrusSqlmapException
      */
     public function facesSummaries(CitrusDatabaseColumn $condition)
     {
@@ -240,6 +255,7 @@ class CitrusService
      *
      * @param CitrusDatabaseColumn $condition
      * @return CitrusDatabaseColumn
+     * @throws CitrusSqlmapException
      */
     public function facesSummary(CitrusDatabaseColumn $condition)
     {
@@ -253,6 +269,7 @@ class CitrusService
      *
      * @param CitrusDatabaseColumn $condition
      * @return CitrusDatabaseColumn[]
+     * @throws CitrusSqlmapException
      */
     public function facesDetails(CitrusDatabaseColumn $condition)
     {
@@ -266,6 +283,7 @@ class CitrusService
      *
      * @param CitrusDatabaseColumn $condition
      * @return CitrusDatabaseColumn
+     * @throws CitrusSqlmapException
      */
     public function facesDetail(CitrusDatabaseColumn $condition)
     {
@@ -279,6 +297,7 @@ class CitrusService
      *
      * @param CitrusDatabaseColumn $condition
      * @return array
+     * @throws CitrusSqlmapException
      */
     public function nameSummaries(CitrusDatabaseColumn $condition)
     {
@@ -292,6 +311,7 @@ class CitrusService
      *
      * @param CitrusDatabaseColumn $condition
      * @return CitrusDatabaseColumn
+     * @throws CitrusSqlmapException
      */
     public function nameSummary(CitrusDatabaseColumn $condition)
     {
@@ -305,6 +325,7 @@ class CitrusService
      *
      * @param CitrusDatabaseColumn $condition
      * @return int
+     * @throws CitrusSqlmapException
      */
     public function nameCount(CitrusDatabaseColumn $condition)
     {
@@ -317,7 +338,8 @@ class CitrusService
      * call dao
      * なるべく継承しabstractとして扱う、エラー回避としてCitruSqlmapClientを返す
      *
-     * @return  CitrusSqlmapCrud
+     * @return CitrusSqlmapCrud
+     * @throws CitrusSqlmapException
      */
     public function callDao()
     {

--- a/bin/database.php
+++ b/bin/database.php
@@ -45,7 +45,7 @@ $directory = $settings['--directory'];
 // 設定(タイプ)
 $type = $settings['--type'];
 // 設定(テーブル名)
-$tablename = $settings['--table-name'];
+$table_name = $settings['--table-name'];
 
 // application configure
 $application_directory = dirname(__FILE__) . '/../' . $directory;
@@ -67,18 +67,27 @@ switch ($type)
 {
     // Property生成処理
     case CitrusDatabaseGenerate::PROPERTY :
-        $propertyname = $settings['--property-name'];
-        CitrusDatabaseGenerate::property($dsns, $tablename, $propertyname);
+        $property_name = $settings['--property-name'];
+        CitrusDatabaseGenerate::property($dsns, $table_name, $property_name);
         break;
     // Dao生成処理
     case CitrusDatabaseGenerate::DAO :
-        $daoname = $settings['--dao-name'];
-        CitrusDatabaseGenerate::dao($tablename, $daoname);
+        $dao_name = $settings['--dao-name'];
+        CitrusDatabaseGenerate::dao($table_name, $dao_name);
         break;
     // Condition生成処理
     case CitrusDatabaseGenerate::CONDITION :
-        $conditionname = $settings['--condition-name'];
-        CitrusDatabaseGenerate::condition($tablename, $conditionname);
+        $condition_name = $settings['--condition-name'];
+        CitrusDatabaseGenerate::condition($table_name, $condition_name);
+        break;
+    // Property,Dao,Condition生成処理
+    case CitrusDatabaseGenerate::ALL :
+        $property_name = $settings['--property-name'];
+        $dao_name = $settings['--dao-name'];
+        $condition_name = $settings['--condition-name'];
+        CitrusDatabaseGenerate::property($dsns, $table_name, $property_name);
+        CitrusDatabaseGenerate::dao($table_name, $dao_name);
+        CitrusDatabaseGenerate::condition($table_name, $condition_name);
         break;
     default:
 }

--- a/calendar/holiday/Japanese.class.php
+++ b/calendar/holiday/Japanese.class.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * @copyright   Copyright 2018, Citrus/besidesplus All Rights Reserved.
+ * @author      take64 <take64@citrus.tk>
+ * @license     http://www.citrus.tk/
+ */
+
+namespace Citrus\Calendar\Holiday;
+
+
+use Citrus\Citrus;
+use Citrus\CitrusConfigure;
+use Citrus\CitrusObject;
+use Citrus\Sqlmap\CitrusSqlmapCondition;
+
+class CitrusCalendarHolidayJapanese extends CitrusObject
+{
+    const HOLIDAYS = [
+        2018 => [
+            1 => [
+                1 => '元日',
+                8 => '成人の日',
+                11 => '建国記念の日',
+            ],
+            2 => [
+                12 => '休日',
+            ],
+            3 => [
+                21 => '春分の日',
+            ],
+            4 => [
+                29 => '昭和の日',
+                30 => '休日',
+            ],
+            5 => [
+                3 => '憲法記念日',
+                4 => 'みどりの日',
+                5 => 'こどもの日',
+            ],
+            6 => [
+
+            ],
+            7 => [
+                16 => '海の日',
+            ],
+            8 => [
+                11 => '山の日',
+            ],
+            9 => [
+                17 => '敬老の日',
+                23 => '秋分の日',
+                24 => '休日',
+            ],
+            10 => [
+                8 => '体育の日',
+            ],
+            11 => [
+                3 => '文化の日',
+                23 => '勤労感謝の日',
+            ],
+            12 => [
+                23 => '天皇誕生日',
+                24 => '休日',
+            ],
+        ],
+        2019 => [
+            1 => [
+                1 => '元日',
+                14 => '成人の日',
+            ],
+            2 => [
+                11 => '建国記念の日',
+            ],
+            3 => [
+                21 => '春分の日',
+            ],
+            4 => [
+                29 => '昭和の日',
+            ],
+            5 => [
+                3 => '憲法記念日',
+                4 => 'みどりの日',
+                5 => 'こどもの日',
+                6 => '休日',
+            ],
+            6 => [
+            ],
+            7 => [
+                15 => '海の日',
+            ],
+            8 => [
+                11 => '山の日',
+                12 => '休日',
+            ],
+            9 => [
+                16 => '敬老の日',
+                23 => '秋分の日',
+            ],
+            10 => [
+                14 => '体育の日',
+            ],
+            11 => [
+                3 => '文化の日',
+                4 => '休日',
+                23 => '勤労感謝の日',
+            ],
+            12 => [
+            ],
+        ],
+    ];
+
+
+
+    /**
+     * 祝日かどうか
+     * (2018 - 2019)
+     *
+     * @param string $date 日付文字列
+     * @return bool true:祝日,false:祝日ではない
+     */
+    public static function isHoliday(string $date)
+    {
+        $timestamp = strtotime($date);
+        $year   = date('Y', $timestamp);
+        $month  = date('n', $timestamp);
+        $day    = date('j', $timestamp);
+
+        if (isset(self::HOLIDAYS[$year]) === true
+            && isset(self::HOLIDAYS[$year][$month]) === true
+            && isset(self::HOLIDAYS[$year][$month][$day]) === true)
+        {
+            return true;
+        }
+        return false;
+    }
+}

--- a/controller/Xhr.class.php
+++ b/controller/Xhr.class.php
@@ -19,6 +19,7 @@ use Citrus\Database\CitrusDatabaseColumn;
 use Citrus\Document\CitrusDocumentPager;
 use Citrus\Message\CitrusMessageItem;
 use Citrus\Sqlmap\CitrusSqlmapCondition;
+use Citrus\Sqlmap\CitrusSqlmapException;
 use Citrus\Xhr\CitrusXhrElement;
 use Citrus\Xhr\CitrusXhrResult;
 
@@ -228,6 +229,7 @@ class CitrusControllerXhr
      * サマリの取得
      *
      * @return  CitrusXhrResult
+     * @throws CitrusSqlmapException
      */
     public function facesDetail() : CitrusXhrResult
     {
@@ -287,6 +289,7 @@ class CitrusControllerXhr
      * の削除
      *
      * @return  CitrusXhrResult
+     * @throws CitrusSqlmapException
      */
     public function remove()
     {
@@ -305,6 +308,7 @@ class CitrusControllerXhr
      * サマリリストの取得
      *
      * @return  CitrusXhrResult
+     * @throws CitrusSqlmapException
      */
     public function selections()
     {
@@ -359,6 +363,7 @@ class CitrusControllerXhr
      * サマリリストの取得
      *
      * @return  CitrusXhrResult
+     * @throws CitrusSqlmapException
      */
     public function suggests()
     {

--- a/controller/Xhr.class.php
+++ b/controller/Xhr.class.php
@@ -173,6 +173,7 @@ class CitrusControllerXhr
      * サマリリストの取得
      *
      * @return CitrusXhrResult
+     * @throws CitrusException
      */
     public function facesSummaries() : CitrusXhrResult
     {
@@ -228,7 +229,7 @@ class CitrusControllerXhr
      * call summary record
      * サマリの取得
      *
-     * @return  CitrusXhrResult
+     * @return CitrusXhrResult
      * @throws CitrusSqlmapException
      */
     public function facesDetail() : CitrusXhrResult
@@ -250,11 +251,14 @@ class CitrusControllerXhr
         return new CitrusXhrResult($detail->properties());
     }
 
+
+
     /**
      * regist item
      * の登録
      *
-     * @return  CitrusXhrResult
+     * @return CitrusXhrResult
+     * @throws CitrusException
      */
     public function modify()
     {
@@ -284,11 +288,13 @@ class CitrusControllerXhr
         return new CitrusXhrResult([$result]);
     }
 
+
+
     /**
      * remove & item
      * の削除
      *
-     * @return  CitrusXhrResult
+     * @return CitrusXhrResult
      * @throws CitrusSqlmapException
      */
     public function remove()
@@ -302,12 +308,14 @@ class CitrusControllerXhr
         $entity = $this->callFormmap()->generate($this->formmap_namespace, $this->formmap_edit_id);
         return new CitrusXhrResult([$this->callService()->remove($entity->getCondition())]);
     }
-    
+
+
+
     /**
      * call summary list
      * サマリリストの取得
      *
-     * @return  CitrusXhrResult
+     * @return CitrusXhrResult
      * @throws CitrusSqlmapException
      */
     public function selections()
@@ -341,8 +349,7 @@ class CitrusControllerXhr
             foreach ($list as &$one)
             {
                 $one->remove(array('status', 'schema',
-                                   'resist_user_cd', 'resist_timestamp',
-                                   'modify_user_cd', 'modify_timestamp',
+                                   'resisted_at', 'modified_at',
                                    'condition'));
                 $one->null2blank();
             }
@@ -360,7 +367,7 @@ class CitrusControllerXhr
      * call summary list
      * サマリリストの取得
      *
-     * @return  CitrusXhrResult
+     * @return CitrusXhrResult
      * @throws CitrusSqlmapException
      */
     public function suggests()
@@ -389,12 +396,13 @@ class CitrusControllerXhr
         return new CitrusXhrResult($result);
     }
 
+
+
     /**
-     * on document_role toggle
-     * 画面ロールの登録
+     * toggle on
      *
-     * @access  public
-     * @return  CitrusXhrResult
+     * @return CitrusXhrResult
+     * @throws CitrusException
      */
     public function on()
     {
@@ -421,16 +429,16 @@ class CitrusControllerXhr
             }
         }
 
-        return new CitrusXhrResult($result);
+        return new CitrusXhrResult([$result]);
     }
 
 
 
     /**
-     * toggle document_role off
-     * 画面ロールの登録
+     * toggle off
      *
-     * @return  CitrusXhrResult
+     * @return CitrusXhrResult
+     * @throws CitrusException
      */
     public function off()
     {
@@ -451,8 +459,10 @@ class CitrusControllerXhr
             $result = $this->callService()->remove($entity->toCondition());
         }
 
-        return new CitrusXhrResult($result);
+        return new CitrusXhrResult([$result]);
     }
+
+
 
     /**
      * call service

--- a/controller/Xhr.class.php
+++ b/controller/Xhr.class.php
@@ -328,10 +328,8 @@ class CitrusControllerXhr
         }
         $condition->pageLimit();
         
-        // count
-        
         // call list
-        $list = $this->callService()->selections($condition);
+        $list = $this->callService()->facesSelections($condition);
         $count = 0;
 
         // data exist

--- a/database/Generate.class.php
+++ b/database/Generate.class.php
@@ -23,6 +23,9 @@ class CitrusDatabaseGenerate
     /** @var string */
     const CONDITION = 'condition';
 
+    /** @var string */
+    const ALL = 'all';
+
 
 
     /**

--- a/formmap/Element.class.php
+++ b/formmap/Element.class.php
@@ -466,6 +466,41 @@ class CitrusFormmapElement extends CitrusObject
 
 
     /**
+     * value convert type
+     */
+    public function convertType()
+    {
+        // result value
+        $result = $this->value;
+
+        // null return
+        if (is_null($result) === true)
+        {
+            return ;
+        }
+
+        // convert
+        $is_converted = false;
+        switch ($this->var_type)
+        {
+            case self::VAR_TYPE_INT:
+                $is_converted = settype($result, 'int');
+                break;
+            case self::VAR_TYPE_FLOAT:
+            case self::VAR_TYPE_NUMERIC:
+                $is_converted = settype($result, 'float');
+                break;
+        }
+
+        if ($is_converted === true)
+        {
+            $this->value = $result;
+        }
+    }
+
+
+
+    /**
      * value filter
      *
      * @return mixed|null

--- a/formmap/Element.class.php
+++ b/formmap/Element.class.php
@@ -80,6 +80,9 @@ class CitrusFormmapElement extends CitrusObject
     /** form type text */
     const FORM_TYPE_TEXT = 'text';
 
+    /** form type text */
+    const FORM_TYPE_TEXTAREA = 'textarea';
+
     /** form type search */
     const FORM_TYPE_SEARCH = 'search';
 
@@ -233,7 +236,8 @@ class CitrusFormmapElement extends CitrusObject
             self::FORM_TYPE_SELECT,
             self::FORM_TYPE_BUTTON,
             self::FORM_TYPE_LABEL,
-            self::HTML_TAG_SPAN
+            self::HTML_TAG_SPAN,
+            self::FORM_TYPE_TEXTAREA,
         ]);
 
         // 要素フォーマット

--- a/formmap/Element.class.php
+++ b/formmap/Element.class.php
@@ -544,7 +544,6 @@ class CitrusFormmapElement extends CitrusObject
      * validate value required
      *
      * @return bool
-     * @throws CitrusException
      */
     protected function _validateRequired() : bool
     {

--- a/formmap/Textarea.class.php
+++ b/formmap/Textarea.class.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * @copyright   Copyright 2017, Citrus/besidesplus All Rights Reserved.
+ * @author      take64 <take64@citrus.tk>
+ * @license     http://www.citrus.tk/
+ */
+
+namespace Citrus\Formmap;
+
+
+use Citrus\CitrusNVL;
+
+class CitrusFormmapTextarea extends CitrusFormmapElement
+{
+    /**
+     * to string
+     *
+     * @param array $appends
+     * @return string
+     */
+    public function toString(array $appends = [])
+    {
+        $elements = [
+            'type'          => 'text',
+            'id'            => $this->callPrefixedId(),
+            'name'          => $this->callPrefixedId(),
+//            'value'         => CitrusNVL::coalesceNull($this->value, $this->callValue(), $this->callDefault()),
+//            'default'       => $this->callDefault(),
+            'class'         => $this->class,
+            'style'         => $this->style,
+            'size'          => $this->size,
+            'maxlength'     => $this->max,
+            'placeholder'   => $this->placeholder,
+        ];
+        $elements = self::appendOption($elements, $appends);
+
+        return self::generateTag('textarea', $elements, [ CitrusNVL::coalesceNull($this->value, $this->callValue(), $this->callDefault()) ]);
+    }
+}

--- a/javascript/Extends.js
+++ b/javascript/Extends.js
@@ -160,6 +160,23 @@
                 .replace('%i', ('00' + minute).slice(-2))
                 .replace('%s', ('00' + second).slice(-2));
         },
+        // 日付フォーマット
+        dateFormat: function(_options) {
+            var options = jQuery.extend(true, {
+                date: new Date(),
+                format: 'Y-m-d H:i:s'
+            }, _options);
+
+            var date = options.date;
+            var result = options.format;
+            result = result.replace(/Y/g, date.getFullYear());
+            result = result.replace(/m/g, ('0' + (date.getMonth() + 1)).slice(-2));
+            result = result.replace(/d/g, ('0' + date.getDate()).slice(-2));
+            result = result.replace(/H/g, ('0' + date.getHours()).slice(-2));
+            result = result.replace(/i/g, ('0' + date.getMinutes()).slice(-2));
+            result = result.replace(/s/g, ('0' + date.getSeconds()).slice(-2));
+            return result;
+        },
         escapeText: function(text){
             return text
                 .replace(/&/g, '&amp;')

--- a/javascript/Faces.js
+++ b/javascript/Faces.js
@@ -744,12 +744,13 @@
                                             options.primaries[ky] = $(tr).attr(ky);
                                         });
                                         if(checkbox.attr('checked') === 'checked') {
-                                            dataOn(options);
-                                            $(checkbox).button({label: '選択済'});
-                                        } else {
                                             dataOff(options);
                                             $(checkbox).button({label: '未選択'});
+                                        } else {
+                                            dataOn(options);
+                                            $(checkbox).button({label: '選択済'});
                                         }
+                                        dataLoadList(options);
                                     });
                                 } else {
                                     if(typeof vl['class'] === 'function') {
@@ -845,6 +846,7 @@
                                         dataOn(options);
                                         $(checkbox).button({label: '選択済'});
                                     }
+                                    dataLoadList(options);
                                 });
                                 if(vl['class']) {
                                     td.attr('class', vl['class']);

--- a/library/smarty3_plugins/modifier.empty_default.php
+++ b/library/smarty3_plugins/modifier.empty_default.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * @copyright   Copyright 2017, Citrus/besidesplus All Rights Reserved.
+ * @author      take64 <take64@citrus.tk>
+ * @license     http://www.citrus.tk/
+ */
+
+
+/**
+ * empty評価される場合のデフォルト表示
+ *
+ * @param mixed  $value   評価変数
+ * @param string $default デフォルト内容
+ * @return string
+ */
+function smarty_modifier_empty_default($value, $default = '')
+{
+    if (empty($value) !== true)
+    {
+        return $value;
+    }
+
+    return $default;
+}

--- a/sqlmap/Crud.class.php
+++ b/sqlmap/Crud.class.php
@@ -194,9 +194,9 @@ class CitrusSqlmapCrud extends CitrusSqlmapClient
      * @return CitrusDatabaseColumn[]
      * @throws CitrusSqlmapException
      */
-    public function selections(CitrusDatabaseColumn $condition)
+    public function facesSelections(CitrusDatabaseColumn $condition)
     {
-        return $this->queryForList('selection', $condition);
+        return $this->queryForList('facesSelection', $condition);
     }
 
 
@@ -208,9 +208,9 @@ class CitrusSqlmapCrud extends CitrusSqlmapClient
      * @return CitrusDatabaseColumn
      * @throws CitrusSqlmapException
      */
-    public function selection(CitrusDatabaseColumn $condition)
+    public function facesSelection(CitrusDatabaseColumn $condition)
     {
-        return $this->queryForObject('selection', $condition);
+        return $this->queryForObject('facesSelection', $condition);
     }
 
 

--- a/sqlmap/Parser.class.php
+++ b/sqlmap/Parser.class.php
@@ -523,6 +523,28 @@ class CitrusSqlmapParser
 
 
     /**
+     * isTrue element node parser
+     * isTrueエレメント処理
+     *
+     * @param DOMElement $element
+     * @return CitrusSqlmapDynamic
+     */
+    protected function _isTrue(DOMElement $element) : CitrusSqlmapDynamic
+    {
+        $dynamic = new CitrusSqlmapDynamic($element->attributes);
+
+        $property = $this->callProperty($this->parameter, $dynamic->property);
+
+        if ($property === true)
+        {
+            $dynamic->query = $this->_nodes($element->childNodes);
+        }
+        return $dynamic;
+    }
+
+
+
+    /**
      * node element general parser
      * node エレメント汎用処理
      *

--- a/sqlmap/Parser.class.php
+++ b/sqlmap/Parser.class.php
@@ -501,6 +501,28 @@ class CitrusSqlmapParser
 
 
     /**
+     * isDatetime element node parser
+     * isDatetimeエレメント処理
+     *
+     * @param DOMElement $element
+     * @return CitrusSqlmapDynamic
+     */
+    protected function _isDatetime(DOMElement $element) : CitrusSqlmapDynamic
+    {
+        $dynamic = new CitrusSqlmapDynamic($element->attributes);
+
+        $property = $this->callProperty($this->parameter, $dynamic->property);
+
+        if (strtotime($property) !== false)
+        {
+            $dynamic->query = $this->_nodes($element->childNodes);
+        }
+        return $dynamic;
+    }
+
+
+
+    /**
      * node element general parser
      * node エレメント汎用処理
      *

--- a/sqlmap/Parser.class.php
+++ b/sqlmap/Parser.class.php
@@ -479,6 +479,28 @@ class CitrusSqlmapParser
 
 
     /**
+     * isNumeric element node parser
+     * isNumericエレメント処理
+     *
+     * @param DOMElement $element
+     * @return CitrusSqlmapDynamic
+     */
+    protected function _isNumeric(DOMElement $element) : CitrusSqlmapDynamic
+    {
+        $dynamic = new CitrusSqlmapDynamic($element->attributes);
+
+        $property = $this->callProperty($this->parameter, $dynamic->property);
+
+        if (is_numeric($property) === true)
+        {
+            $dynamic->query = $this->_nodes($element->childNodes);
+        }
+        return $dynamic;
+    }
+
+
+
+    /**
      * node element general parser
      * node エレメント汎用処理
      *


### PR DESCRIPTION
- オートロードから不要なthrowを削除
- 祝日クラスの作成
- Smarty拡張:empty_defaultの作成
- Capsule機能用拡張の追加
- マイグレーションツールにALLを追加
- formmapにtextarea機能の追加
- formmapによる型変更を行う用に変更
- SqlmapExceptionのdoc記述
- sqlmapにisNumericを追加
- sqlmapにisDatetimeを追加
- sqlmapにisTrueを追加
- xhrのdoc修正とコード整形
- facesでのtoggle時にデータロードされる用に変更
- facesExtendsに日付フォーマットを追加
